### PR TITLE
fix: lógica do botão concluir e enviar (colaborador)

### DIFF
--- a/src/components/evaluation/referencias/RefCollaborator.tsx
+++ b/src/components/evaluation/referencias/RefCollaborator.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type FormEvent } from 'react';
 import SearchBar from '../../SearchBar';
 import SearchResults from '../../SearchResults';
+import { useEvaluation } from '../../../contexts/EvaluationProvider';
 
 interface Teammate {
   id: string;
@@ -12,173 +13,159 @@ interface ProjectApiResponse {
   teammates: Teammate[];
 }
 interface Collaborator {
-  id: string;
-  name: string;
-  role: string;
+    id: string;
+    name: string;
+    role: string;
 }
 
 const RefCollaborator = () => {
-  const [allCollaborators, setAllCollaborators] = useState<Collaborator[]>([]);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [filteredResults, setFilteredResults] = useState<Collaborator[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [selectedCollaborator, setSelectedCollaborator] = useState<Collaborator | null>(null);
-  const [justification, setJustification] = useState('');
-  const [completedEvaluations, setCompletedEvaluations] = useState(0);
-  const totalEvaluations = 4;
+    const [allCollaborators, setAllCollaborators] = useState<Collaborator[]>([]);
+    const [searchQuery, setSearchQuery] = useState('');
+    const [filteredResults, setFilteredResults] = useState<Collaborator[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const [selectedCollaborator, setSelectedCollaborator] = useState<Collaborator | null>(null);
+    const [justification, setJustification] = useState('');
+    const totalEvaluations = 1;
 
-  useEffect(() => {
-    const fetchAllTeammates = async () => {
-      setIsLoading(true);
-      try {
-        const token = localStorage.getItem('authToken');
-        if (!token) throw new Error('Token de autenticação não encontrado no localStorage.');
+    const { referenceFeedbackData, addReferenceFeedback, removeReferenceFeedback } = useEvaluation();
 
-        const response = await fetch('/api/projects/teammates', {
-          headers: { Authorization: `Bearer ${token}` },
-        });
-        if (!response.ok) throw new Error(`Falha ao buscar colegas de equipe: ${response.statusText}`);
+    useEffect(() => {
+        const fetchAllTeammates = async () => {
+            setIsLoading(true);
+            try {
+                const token = localStorage.getItem('authToken');
+                if (!token) throw new Error('Token de autenticação não encontrado no localStorage.');
 
-        const projectsData: ProjectApiResponse[] = await response.json();
-        const collaboratorMap = new Map<string, Collaborator>();
-        projectsData.forEach(project => {
-          project.teammates.forEach(teammate => {
-            if (!collaboratorMap.has(teammate.id)) {
-              collaboratorMap.set(teammate.id, {
-                id: teammate.id,
-                name: teammate.name,
-                role: teammate.jobTitle,
-              });
+                const response = await fetch('/api/projects/teammates', {
+                    headers: { 'Authorization': `Bearer ${token}` }
+                });
+                if (!response.ok) throw new Error(`Falha ao buscar colegas de equipe: ${response.statusText}`);
+                
+                const projectsData: ProjectApiResponse[] = await response.json();
+                const collaboratorMap = new Map<string, Collaborator>();
+                projectsData.forEach(project => {
+                    project.teammates.forEach(teammate => {
+                        if (!collaboratorMap.has(teammate.id)) {
+                            collaboratorMap.set(teammate.id, {
+                                id: teammate.id,
+                                name: teammate.name,
+                                role: teammate.jobTitle
+                            });
+                        }
+                    });
+                });
+                setAllCollaborators(Array.from(collaboratorMap.values()));
+            } catch (error) {
+                console.error("Erro ao carregar colaboradores:", error);
+            } finally {
+                setIsLoading(false);
             }
-          });
-        });
-        setAllCollaborators(Array.from(collaboratorMap.values()));
-      } catch (error) {
-        console.error('Erro ao carregar colaboradores:', error);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    fetchAllTeammates();
-  }, []);
+        };
+        fetchAllTeammates();
+    }, []);
 
-  useEffect(() => {
-    if (searchQuery.trim() !== '') {
-      const results = allCollaborators.filter(collaborator =>
-        collaborator.name.toLowerCase().includes(searchQuery.toLowerCase()),
-      );
-      setFilteredResults(results);
-    } else {
-      setFilteredResults([]);
-    }
-  }, [searchQuery, allCollaborators]);
+    useEffect(() => {
+        if (searchQuery.trim() !== '') {
+            const addedIds = referenceFeedbackData.map(f => f.referencedUserId);
+            const results = allCollaborators.filter(c =>
+                !addedIds.includes(c.id) && c.name.toLowerCase().includes(searchQuery.toLowerCase())
+            );
+            setFilteredResults(results);
+        } else {
+            setFilteredResults([]);
+        }
+    }, [searchQuery, allCollaborators, referenceFeedbackData]);
 
-  const handleSelectCollaborator = (collaborator: Collaborator) => {
-    setSelectedCollaborator(collaborator);
-    setJustification('');
-    setSearchQuery('');
-    setFilteredResults([]);
-  };
-
-  const handleClearSelection = () => {
-    setSelectedCollaborator(null);
-    setJustification('');
-  };
-
-  const handleSubmit = async (event: FormEvent) => {
-    event.preventDefault();
-    if (!selectedCollaborator) return;
-
-    const token = localStorage.getItem('authToken');
-    if (!token) {
-      alert('Sessão expirada. Por favor, faça login novamente.');
-      return;
-    }
-
-    const feedbackData = {
-      referencedUserId: selectedCollaborator.id,
-      justification: justification,
+    const handleSelectCollaborator = (collaborator: Collaborator) => {
+        setSelectedCollaborator(collaborator);
+        setJustification('');
+        setSearchQuery('');
+        setFilteredResults([]);
     };
 
-    try {
-      const response = await fetch('/api/evaluations/collaborator/reference-feedback', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(feedbackData),
-      });
-
-      if (response.ok) {
-        alert(`Feedback para ${selectedCollaborator.name} enviado com sucesso!`);
+    const handleClearSelection = () => {
         setSelectedCollaborator(null);
         setJustification('');
-        setCompletedEvaluations(prevCount => Math.min(prevCount + 1, totalEvaluations));
-      } else {
-        const errorResult = await response.json();
-        throw new Error(errorResult.message || 'Falha ao enviar feedback.');
-      }
-    } catch (error) {
-      console.error('Erro ao enviar feedback:', error);
-      alert(`Erro: ${error instanceof Error ? error.message : 'Ocorreu um problema.'}`);
-    }
-  };
+    };
+
+    const handleAddReference = (event: FormEvent) => {
+        event.preventDefault();
+        if (!selectedCollaborator || justification.trim() === '') {
+            alert("Por favor, selecione um colaborador e escreva um feedback.");
+            return;
+        }
+
+        addReferenceFeedback({
+            referencedUserId: selectedCollaborator.id,
+            referencedUserName: selectedCollaborator.name,
+            justification: justification,
+        });
+
+        handleClearSelection();
+    };
 
     return (
         <div className="flex flex-col flex-1">
-            <main className="flex-1"> 
+            <main className="flex-1">
                 <div className="mb-6">
                     <div className="max-w mx-auto relative">
-                    <SearchBar value={searchQuery} onChange={setSearchQuery} />
-                        <SearchResults 
+                        <h2 className="text-lg font-semibold mb-2">Adicionar Referência ({referenceFeedbackData.length}/{totalEvaluations})</h2>
+                        <SearchBar value={searchQuery} onChange={setSearchQuery} />
+                        <SearchResults
                             results={filteredResults}
                             onSelect={handleSelectCollaborator}
-                            isLoading={isLoading && searchQuery.length === 0}
+                            isLoading={isLoading && searchQuery.length > 0}
                         />
                     </div>
 
                     {selectedCollaborator && (
-                        <div className='block w-full p-6 rounded-2xl bg-white shadow-lg'>
+                        <form onSubmit={handleAddReference} className='block w-full mt-4 p-6 rounded-2xl bg-white shadow-lg'>
                             <div className='flex justify-between items-start pr-10'>
                                 <div>
                                     <h1 className='mb-2 ml-30 font-semibold text-md'>{selectedCollaborator.name}</h1>
                                     <h2 className='mb-10 ml-32 font-semibold text-sm text-gray-700'>{selectedCollaborator.role}</h2>
                                 </div>
-                                <button
-                                    onClick={handleClearSelection}
-                                    className='text-gray-400 hover:text-red-500 font-bold text-2xl px-2'
-                                    title='Remover seleção'
-                                >
+                                <button type="button" onClick={handleClearSelection} className='text-gray-400 hover:text-red-500 font-bold text-2xl px-2' title='Remover seleção'>
                                     &times;
                                 </button>
                             </div>
-                            
-                            <div className='mt-5 flex justify-center'>
+
+                            <div className='mt-5 flex flex-col items-center'>
                                 <textarea
                                     placeholder={`Escreva seu feedback sobre ${selectedCollaborator.name}...`}
                                     rows={3}
                                     className='block w-full max-w-2xl p-3 rounded-lg border border-gray-300 sm:text-sm resize-none'
                                     value={justification}
                                     onChange={(e) => setJustification(e.target.value)}
+                                    required
                                     autoFocus
                                 />
+                                <button type="submit" className="mt-4 bg-[#085F60] text-white font-medium text-sm py-2 px-6 rounded-sm hover:bg-[#086014d5]">
+                                    Adicionar Feedback
+                                </button>
                             </div>
-                        </div>
+                        </form>
                     )}
                 </div>
-                
-                <div className='max-w mx-auto mt-5'>
-                    <div className='flex justify-between items-center mb-2'>
-                        <h3 className='font-semibold text-gray-800'>Status da Avaliação</h3>
-                        <span className='text-sm font-bold text-gray-600'>{completedEvaluations}/{totalEvaluations} Concluído</span>
-                    </div>
-                    <div className='w-full bg-gray-200 rounded-full h-2.5'>
-                        <div 
-                            className='bg-green-600 h-2.5 rounded-full transition-all duration-500'
-                            style={{ width: `${(completedEvaluations / totalEvaluations) * 100}%` }}
-                        ></div>
-                    </div>
+
+                <hr />
+                <h2 className="text-lg font-semibold mt-6 mb-2">Referências Adicionadas</h2>
+                <div className="space-y-4">
+                    {referenceFeedbackData.length > 0 ? (
+                        referenceFeedbackData.map(feedback => (
+                            <div key={feedback.referencedUserId} className="bg-white p-4 rounded-lg shadow flex justify-between items-center">
+                                <div>
+                                    <p className="font-semibold">{feedback.referencedUserName}</p>
+                                    <p className="text-sm text-gray-600 mt-1 italic">"{feedback.justification}"</p>
+                                </div>
+                                <button onClick={() => removeReferenceFeedback(feedback.referencedUserId)} className="text-red-500 hover:text-red-700 font-semibold">
+                                    Remover
+                                </button>
+                            </div>
+                        ))
+                    ) : (
+                        <p className="text-gray-500">Nenhum feedback de referência foi adicionado ainda.</p>
+                    )}
                 </div>
             </main>
         </div>

--- a/src/pages/evaluation/EvaluationCycle.tsx
+++ b/src/pages/evaluation/EvaluationCycle.tsx
@@ -4,6 +4,7 @@ import Evaluation360 from '../../components/evaluation/360evaluation/360Evaluati
 import Mentoring from '../../components/evaluation/mentoring/Mentoring';
 import SelfEvaluation from '../../components/evaluation/selfevaluation/SelfEvaluation';
 import RefCollaborator from '../../components/evaluation/referencias/RefCollaborator';
+import { useEvaluation } from '../../contexts/EvaluationProvider';
 
 const NAV_BUTTONS = ['Autoavaliação', 'Avaliação 360', 'Mentoring', 'Referências'] as const;
 type NavButtonType = typeof NAV_BUTTONS[number];
@@ -11,25 +12,44 @@ type NavButtonType = typeof NAV_BUTTONS[number];
 const EvaluationPage = () => {
   const [activeButton, setActiveButton] = useState<NavButtonType>('Autoavaliação');
 
+  const { 
+    isSelfEvaluationComplete, 
+    isMentoringComplete,
+    isEvaluation360Complete,
+    evaluations360,
+    isReferenceFeedbackComplete 
+  } = useEvaluation();
+
+  // Verificação do estado de conclusão de cada módulo
+  const selfEvalCompleted = isSelfEvaluationComplete();
+  const mentoringCompleted = isMentoringComplete();
+  const all360EvaluationsCompleted = evaluations360.length > 0 && evaluations360.every(e => isEvaluation360Complete(e.collaborator.id));
+  const referencesCompleted = isReferenceFeedbackComplete();
+
+  // O botão é desabilitado se QUALQUER uma das seções estiver incompleta
+  const isFinalSaveDisabled = !selfEvalCompleted || !mentoringCompleted || !all360EvaluationsCompleted || !referencesCompleted;
+
+  const handleSaveAndSubmit = () => {
+    if (isFinalSaveDisabled) {
+      alert("Por favor, preencha todas as seções obrigatórias da avaliação.");
+      return;
+    }
+    // Lógica para coletar TODOS os dados do contexto e enviar para a API
+    console.log("Todos os dados prontos para serem enviados!");
+    alert("Avaliação enviada com sucesso!");
+  };
+
   return (
     <div>
       <div className="pt-36 min-h-screen bg-[#F1F1F1]">
         <Topbar
-          onSave={function (): void {
-            throw new Error('Function not implemented.');
-          }}
-          isSaveDisabled={false}
+          onSave={handleSaveAndSubmit}
+          isSaveDisabled={isFinalSaveDisabled}
           activeButton={activeButton}
           onNavButtonClick={setActiveButton}
         />
-        <main className=" bg-[#F1F1F1]">
-          {/* conteúdo da página de avaliação */}
-          {activeButton === 'Autoavaliação' && (
-            <SelfEvaluation 
-              initialSelfAssessmentData={null} 
-              cycleId="2025.1" 
-            />
-          )}
+        <main className="bg-[#F1F1F1]">
+          {activeButton === 'Autoavaliação' && <SelfEvaluation initialSelfAssessmentData={null} cycleId="2025.1" />}
           {activeButton === 'Avaliação 360' && <Evaluation360 />}
           {activeButton === 'Mentoring' && <Mentoring />}
           {activeButton === 'Referências' && <RefCollaborator />}


### PR DESCRIPTION
Alterações realizadas: 
- Mudança na lógica do botão "concluir e enviar" presente nas avaliações do colaborador. Agora, o botão só é clicável quando todas as avaliações e campos de justificativa forem devidamente preenchidos;
- Tratamento do fluxo de conclusão das referências de colaborador estava sendo realizado e um arquivo separado das demais avaliações, agora todas as avaliações (incluindo referências) estão sendo tratadas no mesmo arquivo.
