### PR TITLE
Feat: add methods to export csv and json brutal facts data files

### DIFF
--- a/src/pages/manager/brutal-facts/components/BrutalFactsHeader.tsx
+++ b/src/pages/manager/brutal-facts/components/BrutalFactsHeader.tsx
@@ -1,10 +1,94 @@
 import { HiDownload } from 'react-icons/hi';
+import { FaFileCsv, FaFileCode } from 'react-icons/fa';
+import { useState, useRef, useEffect } from 'react';
+import type {
+  BrutalFactsMetricsDto,
+  TeamAnalysisDto,
+  TeamHistoricalPerformanceDto,
+} from '../../../../types/brutalFacts';
+import {
+  exportBrutalFactsToCSV,
+  exportBrutalFactsToJSON,
+  exportTeamAnalysisToCSV,
+  exportTeamAnalysisToJSON,
+  exportHistoricalPerformanceToCSV,
+  exportHistoricalPerformanceToJSON,
+} from '../../../../utils/exportUtils';
 
 interface BrutalFactsHeaderProps {
-  onToggleDownload: () => void;
+  brutalFactsData?: BrutalFactsMetricsDto | null;
+  teamAnalysisData?: TeamAnalysisDto | null;
+  historicalPerformanceData?: TeamHistoricalPerformanceDto | null;
 }
 
-const BrutalFactsHeader = ({ onToggleDownload }: BrutalFactsHeaderProps) => {
+const BrutalFactsHeader = ({
+  brutalFactsData,
+  teamAnalysisData,
+  historicalPerformanceData,
+}: BrutalFactsHeaderProps) => {
+  const [showDropdown, setShowDropdown] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Fecha dropdown quando clica fora
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setShowDropdown(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  const handleExport = (type: 'csv' | 'json', dataType: 'brutal-facts' | 'team-analysis' | 'historical') => {
+    try {
+      switch (dataType) {
+        case 'brutal-facts':
+          if (!brutalFactsData) {
+            alert('Dados do Brutal Facts não disponíveis');
+            return;
+          }
+          if (type === 'csv') {
+            exportBrutalFactsToCSV(brutalFactsData);
+          } else {
+            exportBrutalFactsToJSON(brutalFactsData);
+          }
+          break;
+
+        case 'team-analysis':
+          if (!teamAnalysisData) {
+            alert('Dados da análise da equipe não disponíveis');
+            return;
+          }
+          if (type === 'csv') {
+            // Passa dados históricos para combinar com team analysis
+            exportTeamAnalysisToCSV(teamAnalysisData);
+          } else {
+            exportTeamAnalysisToJSON(teamAnalysisData);
+          }
+          break;
+
+        case 'historical':
+          if (!historicalPerformanceData) {
+            alert('Dados históricos não disponíveis');
+            return;
+          }
+          if (type === 'csv') {
+            exportHistoricalPerformanceToCSV(historicalPerformanceData);
+          } else {
+            exportHistoricalPerformanceToJSON(historicalPerformanceData);
+          }
+          break;
+      }
+      setShowDropdown(false);
+    } catch (error) {
+      console.error('Erro ao exportar:', error);
+      alert('Erro ao exportar arquivo. Tente novamente.');
+    }
+  };
   return (
     <div className='bg-white shadow-sm border-b border-gray-200 px-6 py-4'>
       <div className='flex justify-between items-center'>
@@ -13,14 +97,95 @@ const BrutalFactsHeader = ({ onToggleDownload }: BrutalFactsHeaderProps) => {
           <h1 className='text-xl font-semibold text-gray-800'>Brutal Facts</h1>
         </div>
 
-        {/* Botão de download à direita */}
-        <button
-          onClick={onToggleDownload}
-          className='flex items-center gap-2 px-4 py-2 text-white rounded-lg transition-colors duration-200 font-medium hover:cursor-pointer'
-          style={{ backgroundColor: '#08605F' }}
-        >
-          <HiDownload className='text-lg' />
-        </button>
+        {/* Botão de download com dropdown à direita */}
+        <div className='relative' ref={dropdownRef}>
+          <button
+            onClick={() => setShowDropdown(!showDropdown)}
+            className='flex items-center gap-2 px-4 py-2 text-white rounded-lg transition-colors duration-200 font-medium hover:cursor-pointer'
+            style={{ backgroundColor: '#08605F' }}
+          >
+            <HiDownload className='text-lg' />
+            Exportar
+          </button>
+
+          {/* Dropdown Menu */}
+          {showDropdown && (
+            <div className='absolute right-0 top-full mt-2 w-80 bg-white border border-gray-200 rounded-lg shadow-lg z-50'>
+              <div className='p-4'>
+                <h3 className='text-sm font-semibold text-gray-800 mb-3'>Exportar Dados</h3>
+
+                {/* Brutal Facts */}
+                <div className='mb-4'>
+                  <h4 className='text-xs font-medium text-gray-600 mb-2'>Brutal Facts</h4>
+                  <div className='flex gap-2'>
+                    <button
+                      onClick={() => handleExport('csv', 'brutal-facts')}
+                      disabled={!brutalFactsData}
+                      className='flex items-center gap-1 px-3 py-2 text-xs bg-blue-50 text-blue-700 rounded hover:bg-blue-100 disabled:opacity-50 disabled:cursor-not-allowed'
+                    >
+                      <FaFileCsv />
+                      CSV
+                    </button>
+                    <button
+                      onClick={() => handleExport('json', 'brutal-facts')}
+                      disabled={!brutalFactsData}
+                      className='flex items-center gap-1 px-3 py-2 text-xs bg-green-50 text-green-700 rounded hover:bg-green-100 disabled:opacity-50 disabled:cursor-not-allowed'
+                    >
+                      <FaFileCode />
+                      JSON
+                    </button>
+                  </div>
+                </div>
+
+                {/* Team Analysis */}
+                <div className='mb-4'>
+                  <h4 className='text-xs font-medium text-gray-600 mb-2'>Análise da Equipe</h4>
+                  <div className='flex gap-2'>
+                    <button
+                      onClick={() => handleExport('csv', 'team-analysis')}
+                      disabled={!teamAnalysisData}
+                      className='flex items-center gap-1 px-3 py-2 text-xs bg-blue-50 text-blue-700 rounded hover:bg-blue-100 disabled:opacity-50 disabled:cursor-not-allowed'
+                    >
+                      <FaFileCsv />
+                      CSV
+                    </button>
+                    <button
+                      onClick={() => handleExport('json', 'team-analysis')}
+                      disabled={!teamAnalysisData}
+                      className='flex items-center gap-1 px-3 py-2 text-xs bg-green-50 text-green-700 rounded hover:bg-green-100 disabled:opacity-50 disabled:cursor-not-allowed'
+                    >
+                      <FaFileCode />
+                      JSON
+                    </button>
+                  </div>
+                </div>
+
+                {/* Historical Performance */}
+                <div>
+                  <h4 className='text-xs font-medium text-gray-600 mb-2'>Performance Histórica</h4>
+                  <div className='flex gap-2'>
+                    <button
+                      onClick={() => handleExport('csv', 'historical')}
+                      disabled={!historicalPerformanceData}
+                      className='flex items-center gap-1 px-3 py-2 text-xs bg-blue-50 text-blue-700 rounded hover:bg-blue-100 disabled:opacity-50 disabled:cursor-not-allowed'
+                    >
+                      <FaFileCsv />
+                      CSV
+                    </button>
+                    <button
+                      onClick={() => handleExport('json', 'historical')}
+                      disabled={!historicalPerformanceData}
+                      className='flex items-center gap-1 px-3 py-2 text-xs bg-green-50 text-green-700 rounded hover:bg-green-100 disabled:opacity-50 disabled:cursor-not-allowed'
+                    >
+                      <FaFileCode />
+                      JSON
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/utils/exportUtils.ts
+++ b/src/utils/exportUtils.ts
@@ -1,0 +1,196 @@
+import type { BrutalFactsMetricsDto, TeamAnalysisDto, TeamHistoricalPerformanceDto } from '../types/brutalFacts';
+
+/**
+ * Converte dados para CSV
+ */
+export function convertToCSV(data: unknown[], headers: string[]): string {
+  const csvContent = [
+    headers.join(','),
+    ...data.map(row =>
+      headers
+        .map(header => {
+          let value = (row as Record<string, unknown>)[header];
+          // Tratar valores nulos e strings com vírgulas
+          if (value === null || value === undefined) {
+            value = '';
+          } else if (
+            typeof value === 'string' &&
+            (value.includes(',') || value.includes('"') || value.includes('\n'))
+          ) {
+            value = `"${value.replace(/"/g, '""')}"`;
+          }
+          return value;
+        })
+        .join(','),
+    ),
+  ].join('\n');
+
+  return csvContent;
+}
+
+/**
+ * Faz download de arquivo
+ */
+export function downloadFile(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Exporta dados do Brutal Facts para CSV
+ */
+export function exportBrutalFactsToCSV(data: BrutalFactsMetricsDto): void {
+  // Dados gerais
+  const generalData = [
+    {
+      cycle: data.cycle,
+      overallScoreAverage: data.overallScoreAverage,
+      performanceImprovement: data.performanceImprovement,
+      collaboratorsEvaluatedCount: data.collaboratorsEvaluatedCount,
+      selfAssessmentTeamAverage: data.teamPerformance.selfAssessmentTeamAverage,
+      managerAssessmentTeamAverage: data.teamPerformance.managerAssessmentTeamAverage,
+      finalScoreTeamAverage: data.teamPerformance.finalScoreTeamAverage,
+    },
+  ];
+
+  const generalHeaders = [
+    'cycle',
+    'overallScoreAverage',
+    'performanceImprovement',
+    'collaboratorsEvaluatedCount',
+    'selfAssessmentTeamAverage',
+    'managerAssessmentTeamAverage',
+    'finalScoreTeamAverage',
+  ];
+
+  // Dados dos colaboradores
+  const collaboratorHeaders = [
+    'collaboratorName',
+    'jobTitle',
+    'seniority',
+    'selfAssessmentAverage',
+    'assessment360Average',
+    'managerAssessmentAverage',
+    'finalScore',
+  ];
+
+  // Combinar dados gerais e dos colaboradores
+  const csvContent = [
+    '# Dados Gerais da Equipe',
+    convertToCSV(generalData, generalHeaders),
+    '',
+    '# Dados dos Colaboradores',
+    convertToCSV(data.collaboratorsMetrics, collaboratorHeaders),
+  ].join('\n');
+
+  downloadFile(csvContent, `brutal-facts-${data.cycle}.csv`, 'text/csv;charset=utf-8;');
+}
+
+/**
+ * Exporta dados do Team Analysis para CSV (combinado com dados históricos do mesmo ciclo)
+ */
+export function exportTeamAnalysisToCSV(data: TeamAnalysisDto, historicalData?: TeamHistoricalPerformanceDto): void {
+  // Encontra dados históricos do mesmo ciclo
+  const historicalCycleData = historicalData?.performanceByCycle.find(cycle => cycle.cycle === data.cycle);
+
+  const analysisData = [
+    {
+      // Dados do Team Analysis (sem managerId)
+
+      cycle: data.cycle,
+      totalCollaborators: data.totalCollaborators,
+      teamAverageScore: data.teamAverageScore,
+      highPerformers: data.highPerformers,
+      lowPerformers: data.lowPerformers,
+      behaviorAverage: data.behaviorAverage,
+      executionAverage: data.executionAverage,
+      criticalPerformers: data.criticalPerformers,
+      createdAt: data.createdAt,
+      scoreAnalysisSummary: data.scoreAnalysisSummary,
+      feedbackAnalysisSummary: data.feedbackAnalysisSummary,
+      // Dados históricos do mesmo ciclo (se disponível)
+      ...(historicalCycleData && {
+        averageOverallScore: historicalCycleData.averageOverallScore,
+        averageSelfAssessment: historicalCycleData.averageSelfAssessment,
+        averageReceived360: historicalCycleData.averageReceived360,
+        historicalTotalCollaborators: historicalCycleData.totalCollaborators,
+      }),
+    },
+  ];
+
+  const headers = [
+    // Colunas do Team Analysis
+
+    'cycle',
+    'totalCollaborators',
+    'teamAverageScore',
+    'highPerformers',
+    'lowPerformers',
+    'behaviorAverage',
+    'executionAverage',
+    'criticalPerformers',
+    'createdAt',
+    'scoreAnalysisSummary',
+    'feedbackAnalysisSummary',
+    // Colunas do Historical Performance (se disponível)
+    ...(historicalCycleData
+      ? ['averageOverallScore', 'averageSelfAssessment', 'averageReceived360', 'historicalTotalCollaborators']
+      : []),
+  ];
+
+  const csvContent = convertToCSV(analysisData, headers);
+  downloadFile(csvContent, `team-analysis-${data.cycle}.csv`, 'text/csv;charset=utf-8;');
+}
+
+/**
+ * Exporta dados do Historical Performance para CSV
+ */
+export function exportHistoricalPerformanceToCSV(data: TeamHistoricalPerformanceDto): void {
+  // Apenas dados por ciclo - ciclos como linhas, notas como colunas
+  const cycleHeaders = [
+    'cycle',
+    'averageOverallScore',
+    'averageSelfAssessment',
+    'averageReceived360',
+    'totalCollaborators',
+  ];
+
+  const csvContent = convertToCSV(data.performanceByCycle, cycleHeaders);
+  downloadFile(csvContent, 'team-historical-performance.csv', 'text/csv;charset=utf-8;');
+}
+
+/**
+ * Exporta dados para JSON
+ */
+export function exportToJSON(data: unknown, filename: string): void {
+  const jsonContent = JSON.stringify(data, null, 2);
+  downloadFile(jsonContent, filename, 'application/json;charset=utf-8;');
+}
+
+/**
+ * Exporta dados do Brutal Facts para JSON
+ */
+export function exportBrutalFactsToJSON(data: BrutalFactsMetricsDto): void {
+  exportToJSON(data, `brutal-facts-${data.cycle}.json`);
+}
+
+/**
+ * Exporta dados do Team Analysis para JSON
+ */
+export function exportTeamAnalysisToJSON(data: TeamAnalysisDto): void {
+  exportToJSON(data, `team-analysis-${data.cycle}.json`);
+}
+
+/**
+ * Exporta dados do Historical Performance para JSON
+ */
+export function exportHistoricalPerformanceToJSON(data: TeamHistoricalPerformanceDto): void {
+  exportToJSON(data, 'team-historical-performance.json');
+}


### PR DESCRIPTION
- Add methods to get teamAnalysis, teamHistoricalPerformance and consolidated brutal facts page data for both json and csv formats 